### PR TITLE
Set context path to avoid NPE

### DIFF
--- a/bundles/communities-ugc-migration/src/main/java/com/adobe/communities/ugc/migration/importer/GenericUGCImporter.java
+++ b/bundles/communities-ugc-migration/src/main/java/com/adobe/communities/ugc/migration/importer/GenericUGCImporter.java
@@ -125,7 +125,7 @@ public class GenericUGCImporter extends SlingAllMethodsServlet {
                 final JsonParser jsonParser = new JsonFactory().createParser(inputStream);
                 jsonParser.nextToken(); // get the first token
 
-                importFile(jsonParser, resource, resolver);
+                importFile(jsonParser, resource, resolver, request);
             } else if (fileRequestParameters[0].getFileName().endsWith(".zip")) {
                 ZipInputStream zipInputStream;
                 try {
@@ -149,7 +149,7 @@ public class GenericUGCImporter extends SlingAllMethodsServlet {
 
                         final JsonParser jsonParser = new JsonFactory().createParser(zipInputStream);
                         jsonParser.nextToken(); // get the first token
-                        importFile(jsonParser, resource, resolver);
+                        importFile(jsonParser, resource, resolver, request);
                         zipInputStream.closeEntry();
                         zipEntry = zipInputStream.getNextEntry();
                         counter++;
@@ -199,7 +199,7 @@ public class GenericUGCImporter extends SlingAllMethodsServlet {
                     final JsonParser jsonParser = new JsonFactory().createParser(inputStream);
                     jsonParser.nextToken(); // get the first token
 
-                    importFile(jsonParser, resource, resolver);
+                    importFile(jsonParser, resource, resolver, request);
                     ImportFileUploadServlet.deleteResource(fileResource);
                     return;
                 }
@@ -215,11 +215,12 @@ public class GenericUGCImporter extends SlingAllMethodsServlet {
      * @throws ServletException
      * @throws IOException
      */
-    protected void importFile(final JsonParser jsonParser, final Resource resource, final ResourceResolver resolver)
+    protected void importFile(final JsonParser jsonParser, final Resource resource, final ResourceResolver resolver, final SlingHttpServletRequest request)
             throws ServletException, IOException {
         final UGCImportHelper importHelper = new UGCImportHelper();
         JsonToken token1 = jsonParser.getCurrentToken();
         importHelper.setSocialUtils(socialUtils);
+        importHelper.setRequest(request);
         if (token1.equals(JsonToken.START_OBJECT)) {
             jsonParser.nextToken();
             if (jsonParser.getCurrentName().equals(ContentTypeDefinitions.LABEL_CONTENT_TYPE)) {

--- a/bundles/communities-ugc-migration/src/main/java/com/adobe/communities/ugc/migration/importer/ImportFileUploadServlet.java
+++ b/bundles/communities-ugc-migration/src/main/java/com/adobe/communities/ugc/migration/importer/ImportFileUploadServlet.java
@@ -233,7 +233,7 @@ public class ImportFileUploadServlet extends GenericUGCImporter {
         final ZipInputStream zipInputStream = new ZipInputStream(uploadedFileInputStream);
 
         try {
-            saveExplodedFiles(resolver, folder, writer, zipInputStream, request.getParameter("basePath"));
+            saveExplodedFiles(resolver, folder, writer, zipInputStream, request.getParameter("basePath"), request);
             // close our JSONWriter
             writer.endArray();
             writer.endObject();
@@ -250,7 +250,7 @@ public class ImportFileUploadServlet extends GenericUGCImporter {
     }
 
     private void saveExplodedFiles(final ResourceResolver resolver, final Resource folder, final JSONWriter writer,
-        final ZipInputStream zipInputStream, final String basePath) throws ServletException {
+        final ZipInputStream zipInputStream, final String basePath, final SlingHttpServletRequest request) throws ServletException {
 
         // we need the closeShieldInputStream to prevent the zipInputStream from being closed during resolver.create()
         final CloseShieldInputStream closeShieldInputStream = new CloseShieldInputStream(zipInputStream);
@@ -314,7 +314,7 @@ public class ImportFileUploadServlet extends GenericUGCImporter {
                                     resource = resolver.getResource(resName.substring(0, resName.lastIndexOf("/")));
                                 }
                                 try {
-                                    importFile(jsonParser, resource, resolver);
+                                    importFile(jsonParser, resource, resolver, request);
                                     toDelete.add(file);
                                 } catch (final Exception e) {
                                     // add the file name to our response ONLY if we failed to import it
@@ -454,7 +454,7 @@ public class ImportFileUploadServlet extends GenericUGCImporter {
                     final JsonParser jsonParser = new JsonFactory().createParser(inputStream);
                     jsonParser.nextToken(); // get the first token
 
-                    importFile(jsonParser, resource, serviceUserResolver);
+                    importFile(jsonParser, resource, serviceUserResolver, request);
                     deleteResource(fileResource);
                     return;
                 }

--- a/bundles/communities-ugc-migration/src/main/java/com/adobe/communities/ugc/migration/importer/UGCImportHelper.java
+++ b/bundles/communities-ugc-migration/src/main/java/com/adobe/communities/ugc/migration/importer/UGCImportHelper.java
@@ -44,6 +44,7 @@ import org.apache.jackrabbit.api.security.user.Authorizable;
 import org.apache.jackrabbit.api.security.user.Group;
 import org.apache.jackrabbit.api.security.user.User;
 import org.apache.jackrabbit.api.security.user.UserManager;
+import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.api.resource.ModifyingResourceProvider;
 import org.apache.sling.api.resource.PersistenceException;
@@ -103,6 +104,8 @@ public class UGCImportHelper {
 
     private SocialResourceProvider resProvider;
 
+    private SlingHttpServletRequest request;
+
     /**
      * These values ought to come from com.adobe.cq.social.calendar.CalendarConstants, but that class isn't in the
      * uberjar, so I'll define the constants here instead.
@@ -151,6 +154,12 @@ public class UGCImportHelper {
     public void setSocialUtils(final SocialUtils socialUtils) {
         if (this.socialUtils == null)
             this.socialUtils = socialUtils;
+    }
+
+    public void setRequest(final SlingHttpServletRequest request) {
+        if (this.request == null) {
+            this.request = request;
+        }
     }
 
     public Resource extractResource(final JsonParser parser, final SocialResourceProvider provider,
@@ -474,6 +483,7 @@ public class UGCImportHelper {
         }
         final Map<String, Object> properties = new HashMap<String, Object>();
         properties.put("social:key", jsonParser.getCurrentName());
+        properties.put("contextPath", request.getContextPath());
         Resource post = null;
         jsonParser.nextToken();
         if (jsonParser.getCurrentToken().equals(JsonToken.START_OBJECT)) {


### PR DESCRIPTION
When you import content with `<img src="">` HTML tags, a NPE gets thrown. Setting the `contextPath` in the properties map avoids this NPE. 

Tested in AEM 6.3. I've attached a sample input file and log.

[input.txt](https://github.com/Adobe-Marketing-Cloud/aem-communities-ugc-migration/files/1109470/input.txt)
[npe.txt](https://github.com/Adobe-Marketing-Cloud/aem-communities-ugc-migration/files/1106622/npe.txt)
