### PR TITLE
Feature - Import Embedded Images

### DIFF
--- a/bundles/communities-ugc-migration/pom.xml
+++ b/bundles/communities-ugc-migration/pom.xml
@@ -244,6 +244,11 @@ written permission of Adobe.
             <version>1.9.5</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.1</version>
+        </dependency>
 
     </dependencies>
     <repositories>

--- a/bundles/communities-ugc-migration/src/main/java/com/adobe/communities/ugc/migration/importer/GenericUGCImporter.java
+++ b/bundles/communities-ugc-migration/src/main/java/com/adobe/communities/ugc/migration/importer/GenericUGCImporter.java
@@ -215,12 +215,18 @@ public class GenericUGCImporter extends SlingAllMethodsServlet {
      * @throws ServletException
      * @throws IOException
      */
-    protected void importFile(final JsonParser jsonParser, final Resource resource, final ResourceResolver resolver, final SlingHttpServletRequest request)
+    protected void importFile(final JsonParser jsonParser, final Resource resource, final ResourceResolver resolver,
+                              final SlingHttpServletRequest request)
             throws ServletException, IOException {
         final UGCImportHelper importHelper = new UGCImportHelper();
         JsonToken token1 = jsonParser.getCurrentToken();
         importHelper.setSocialUtils(socialUtils);
         importHelper.setRequest(request);
+        final String importImagesStr = (request.getRequestParameter("importImages") != null) ? request.getRequestParameter("importImages").getString() : null;
+        final String importImagesSrc = (request.getRequestParameter("importImagesSrc") != null) ? request.getRequestParameter("importImagesSrc").getString() : null;
+        final boolean importImages = "true".equals(importImagesStr);
+        importHelper.setImportImages(importImages);
+        importHelper.setImportImagesSrc(importImagesSrc);
         if (token1.equals(JsonToken.START_OBJECT)) {
             jsonParser.nextToken();
             if (jsonParser.getCurrentName().equals(ContentTypeDefinitions.LABEL_CONTENT_TYPE)) {

--- a/bundles/communities-ugc-migration/src/main/java/com/adobe/communities/ugc/migration/importer/ImageUploadUtil.java
+++ b/bundles/communities-ugc-migration/src/main/java/com/adobe/communities/ugc/migration/importer/ImageUploadUtil.java
@@ -1,0 +1,163 @@
+package com.adobe.communities.ugc.migration.importer;
+
+import com.day.text.Text;
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.util.EntityUtils;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jcr.*;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Calendar;
+import java.util.UUID;
+
+public class ImageUploadUtil {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ImageUploadUtil.class);
+
+    private static String IMAGE_ELEMENT = "img";
+    private static String SRC = "src";
+    private static String SRC_ELEMENT = SRC + "=";
+    private static final String TEMP_IMAGE_DIR = "/content/usergenerated/tmp/social/images/";
+
+    /**
+     * Parses the input string for any embedded images (<img>). If any embedded images are found,
+     * they are imported into AEM and the original image source will be updated to the new path.
+     * @param input The input String containing embedded images
+     * @return A modified version of the input string containing references to AEM images.
+     */
+    public static String importImage(final ResourceResolver resourceResolver, final String input, final String include) {
+        String modified = input;
+
+        if (StringUtils.containsIgnoreCase(modified, IMAGE_ELEMENT)) {
+            int startPos = 0;
+            int index = -1;
+
+            while ((index = StringUtils.indexOf(modified, SRC_ELEMENT, startPos)) >= 0) {
+                startPos = index + 1;
+
+                int imgStartPos = StringUtils.indexOf(modified, "\"", index);
+                if (imgStartPos > 0) {
+                    int imgEndPos = StringUtils.indexOf(modified, "\"", imgStartPos + 1);
+                    if (imgEndPos > 0) {
+                        String imgUrl = StringUtils.substring(modified, imgStartPos + 1, imgEndPos);
+                        imgUrl = Text.unescape(imgUrl);
+                        String importedImgUrl = null;
+
+                        // Use filter if specified
+                        if (include != null && imgUrl.contains(include)) {
+                            importedImgUrl = importImageToJcr(resourceResolver, imgUrl);
+                        }
+
+                        // No filter, just import image
+                        if (include == null) {
+                            importedImgUrl = importImageToJcr(resourceResolver, imgUrl);
+                        }
+
+                        if (importedImgUrl != null) {
+                            modified = replace(modified, importedImgUrl, imgStartPos, imgEndPos - imgStartPos);
+                        }
+                    }
+                }
+            }
+        }
+
+        return modified;
+    }
+
+    private static String importImageToJcr(final ResourceResolver resourceResolver, final String url) {
+        if (url == null || StringUtils.isEmpty(url) || url.startsWith(TEMP_IMAGE_DIR)) {
+            return null;
+        }
+
+        String jcrPath = null;
+        HttpClient client = new DefaultHttpClient();
+        HttpGet get = new HttpGet(url);
+        HttpResponse response = null;
+
+        // Download image
+        try {
+            response = client.execute(get);
+        } catch (IOException e) {
+            LOG.error("Error while downloading image.", e);
+        }
+
+        // If the response was successful, proceed with moving image into JCR
+        if (response != null && (response.getStatusLine().getStatusCode() >= 200 && response.getStatusLine().getStatusCode() <= 299)) {
+            byte[] content = null;
+            Node parentNode = resourceResolver.getResource(TEMP_IMAGE_DIR).adaptTo(Node.class);
+
+            try {
+                content = EntityUtils.toByteArray(response.getEntity());
+            } catch (IOException e) {
+                LOG.error("Error while reading HTTP response into byte array.", e);
+            }
+
+            if (parentNode != null && content != null) {
+                String mimeType = response.getEntity().getContentType().toString();
+                String extension = getFileExtension(mimeType);
+                String fileName = UUID.randomUUID().toString() + extension;
+                InputStream is = new ByteArrayInputStream(content);
+                Session session = resourceResolver.adaptTo(Session.class);
+
+                try {
+                    ValueFactory valueFactory = session.getValueFactory();
+                    Binary contentValue = valueFactory.createBinary(is);
+                    Node fileNode = parentNode.addNode(fileName, "nt:file");
+                    fileNode.addMixin("mix:referenceable");
+                    Node resNode = fileNode.addNode("jcr:content", "nt:resource");
+                    resNode.setProperty("jcr:mimeType", response.getEntity().getContentType().toString());
+                    resNode.setProperty("jcr:data", contentValue);
+                    Calendar lastModified = Calendar.getInstance();
+                    lastModified.setTimeInMillis(lastModified.getTimeInMillis());
+                    resNode.setProperty("jcr:lastModified", lastModified);
+
+                    session.save();
+                    jcrPath = fileNode.getPath();
+                } catch (RepositoryException e) {
+                    LOG.error("Error moving image into JCR.", e);
+                }
+            }
+        }
+
+        return jcrPath;
+    }
+
+    private static String getFileExtension(String mimeType) {
+        String extension = "";
+
+        if (StringUtils.containsIgnoreCase(mimeType, "gif")) {
+            extension = ".gif";
+        } else if (StringUtils.containsIgnoreCase(mimeType, "jpg")) {
+            extension = ".jpeg";
+        } else if (StringUtils.containsIgnoreCase(mimeType, "jpg")) {
+            extension = ".jpg";
+        } else if (StringUtils.containsIgnoreCase(mimeType, "png")) {
+            extension = ".png";
+        } else if (StringUtils.containsIgnoreCase(mimeType, "svg+xml")) {
+            extension = ".svg";
+        }
+
+        LOG.info("extension");
+
+        return extension;
+    }
+
+    private static String replace(String text, String replacement, int startIndex, int length) {
+        int replLength = replacement.length();
+        int increase = replacement.length() - length;
+        increase = increase < 0 ? 0 : increase;
+        increase *= 16;
+        StringBuilder buf = new StringBuilder(text.length() + increase);
+        buf = buf.append(text, 0, startIndex + 1).append(replacement).append(text.substring(startIndex + length));
+
+        return buf.toString();
+    }
+}

--- a/bundles/communities-ugc-migration/src/main/java/com/adobe/communities/ugc/migration/importer/ImageUploadUtil.java
+++ b/bundles/communities-ugc-migration/src/main/java/com/adobe/communities/ugc/migration/importer/ImageUploadUtil.java
@@ -52,12 +52,12 @@ public class ImageUploadUtil {
                         String importedImgUrl = null;
 
                         // Use filter if specified
-                        if (include != null && imgUrl.contains(include)) {
+                        if (!StringUtils.isEmpty(include) && imgUrl.contains(include)) {
                             importedImgUrl = importImageToJcr(resourceResolver, imgUrl);
                         }
 
                         // No filter, just import image
-                        if (include == null) {
+                        if (StringUtils.isEmpty(include)) {
                             importedImgUrl = importImageToJcr(resourceResolver, imgUrl);
                         }
 
@@ -79,14 +79,14 @@ public class ImageUploadUtil {
 
         String jcrPath = null;
         HttpClient client = new DefaultHttpClient();
-        HttpGet get = new HttpGet(url);
+        HttpGet get = new HttpGet(url.replaceAll(" ", "%20"));
         HttpResponse response = null;
 
         // Download image
         try {
             response = client.execute(get);
-        } catch (IOException e) {
-            LOG.error("Error while downloading image.", e);
+        } catch (Exception e) {
+            LOG.error("Error while downloading image: " + url, e);
         }
 
         // If the response was successful, proceed with moving image into JCR

--- a/bundles/communities-ugc-migration/src/main/java/com/adobe/communities/ugc/migration/importer/ImageUploadUtil.java
+++ b/bundles/communities-ugc-migration/src/main/java/com/adobe/communities/ugc/migration/importer/ImageUploadUtil.java
@@ -84,6 +84,11 @@ public class ImageUploadUtil {
             return null;
         }
 
+        // Don't import images from file system
+        if (url.startsWith("file://")) {
+            return null;
+        }
+
         String jcrPath = null;
         HttpClient client = new DefaultHttpClient();
         HttpGet get = new HttpGet(url.replaceAll(" ", "%20"));

--- a/bundles/communities-ugc-migration/src/main/java/com/adobe/communities/ugc/migration/importer/ImageUploadUtil.java
+++ b/bundles/communities-ugc-migration/src/main/java/com/adobe/communities/ugc/migration/importer/ImageUploadUtil.java
@@ -46,10 +46,10 @@ public class ImageUploadUtil {
             int startPos = 0;
             int index = -1;
 
-            while ((index = StringUtils.indexOf(modified, IMAGE_ELEMENT, startPos)) >= 0) {
+            while ((index = StringUtils.indexOfIgnoreCase(modified, IMAGE_ELEMENT, startPos)) >= 0) {
                 startPos = index + 1;
                 int imageElementEnd = StringUtils.indexOf(modified, ">", index);
-                int indexSrc = StringUtils.indexOf(modified, SRC_ELEMENT, index);
+                int indexSrc = StringUtils.indexOfIgnoreCase(modified, SRC_ELEMENT, index);
                 int imgStartPos = StringUtils.indexOf(modified, "\"", indexSrc);
                 if (imgStartPos > 0 && imgStartPos< imageElementEnd) {
                     int imgEndPos = StringUtils.indexOf(modified, "\"", imgStartPos + 1);

--- a/bundles/communities-ugc-migration/src/main/java/com/adobe/communities/ugc/migration/importer/UGCImportHelper.java
+++ b/bundles/communities-ugc-migration/src/main/java/com/adobe/communities/ugc/migration/importer/UGCImportHelper.java
@@ -106,6 +106,9 @@ public class UGCImportHelper {
 
     private SlingHttpServletRequest request;
 
+    private boolean importImages = false;
+
+    private String importImagesSrc = null;
     /**
      * These values ought to come from com.adobe.cq.social.calendar.CalendarConstants, but that class isn't in the
      * uberjar, so I'll define the constants here instead.
@@ -160,6 +163,14 @@ public class UGCImportHelper {
         if (this.request == null) {
             this.request = request;
         }
+    }
+
+    public void setImportImages(final boolean importImages) {
+        this.importImages = importImages;
+    }
+
+    public void setImportImagesSrc(final String importImagesSrc) {
+        this.importImagesSrc = importImagesSrc;
     }
 
     public Resource extractResource(final JsonParser parser, final SocialResourceProvider provider,
@@ -504,7 +515,7 @@ public class UGCImportHelper {
                         if (value.equals("true") || value.equals("false")) {
                             properties.put(label, jsonParser.getValueAsBoolean());
                         } else {
-                            final String decodedValue = URLDecoder.decode(value, "UTF-8");
+                            String decodedValue = URLDecoder.decode(value, "UTF-8");
                             if (label.equals("language")) {
                                 properties.put("mtlanguage", decodedValue);
                             } else {
@@ -512,6 +523,9 @@ public class UGCImportHelper {
                                 if (label.equals("userIdentifier")) {
                                     author = decodedValue;
                                 } else if (label.equals("jcr:description")) {
+                                    if (importImages) {
+                                        decodedValue = ImageUploadUtil.importImage(resolver, decodedValue, importImagesSrc);
+                                    }
                                     properties.put("message", decodedValue);
                                 }
                             }


### PR DESCRIPTION
Enhanced importer to support moving external images into AEM. You can specify an optional form field `importImages` with a value of true or false. You can set an additional form field `importImagesSrc` that takes a string to filter out any image source that do not contain that string.

Example usage:
`curl -i -u admin:admin -X POST -F file=@test.json -F importImages=true -F importImagesSrc=lorem http://localhost:4503/services/social/ugc/import?path=/content/sites/test/en/qna/jcr%3Acontent/content/primary/qna`