### PR TITLE
Added null check for user and additional logging when importing social graph

### DIFF
--- a/bundles/communities-ugc-migration/src/main/java/com/adobe/communities/ugc/migration/importer/UGCImportHelper.java
+++ b/bundles/communities-ugc-migration/src/main/java/com/adobe/communities/ugc/migration/importer/UGCImportHelper.java
@@ -900,6 +900,18 @@ public class UGCImportHelper {
         }
     }
 
+    public static User getUser(final String userId, final ResourceResolver resolver) {
+        UserManager userManager = resolver.adaptTo(UserManager.class);
+        User user = null;
+        try {
+            user = (User) userManager.getAuthorizable(userId);
+        } catch (RepositoryException e) {
+            LOG.error("Error getting user: " + userId, e);
+        }
+
+        return user;
+    }
+
     private static String randomHexString() {
         Random rand = new Random();
         int hexInt = rand.nextInt(0X10000);


### PR DESCRIPTION
When importing social graphs into AEM, the importer will fail if a user does not exist. e.g.,

```
{
  "foo@bar.com": [
    "lorem@ipsum.com"
  ]
}
```

For the above JSON snippet, if the user `foo@bar.com` didn't exist, the entire import would fail. I've added a null check for users and instead of dropping the entire import, it'll just log a message.