### PR TITLE
CQ-4269521: old badges(<=6.3) migration to new badges path

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,41 @@ curl -i -u"admin:admin" -X POST -F"file=@/Users/sample/Downloads/socialGraph.jso
 3. Use curl to upload the messages archive file to the import servlet
 Example import command:
 curl -i -u"admin:admin" -X POST -F"file=@/Users/sample/Downloads/export.zip" http://localhost:4503/services/social/messages/import
+
+# communities-badges-migration
+
+Communities Badges migration migrates badges paths from /etc/community/badging/images to new paths (/libs/community/badging/images, /content/community/badging/images).
+This migration is required for a customer upgrading to 6.4 or higher version from 6.3 or lower version. If this migration is not done, User's old badges would continue
+pointing to old paths(/etc).
+
+Pre-requisite:
+  - Make sure old badges images are present before running migration script.
+  - Users should not be assigned any new badges prior migration as it might conflict with old badges during migration.
+
+Steps to migrate :
+
+1. Change the scoring path and badging paths in constant file (com.adobe.cq.social.badges.resource.migrator.internal.BadgingContants).
+2. build cq-social-badges-migrator bundle.
+3. On any of publisher instance:
+	a. - Stop the instance.
+	b. - install the cq-social-badges-migrator bundle.
+	c. - Add a logger for package "com.adobe.cq.social.badges.resource"  from http://<host>:<port>/system/console/slinglog
+
+4. Create New Badges
+
+   - Make a HTTP POST call to http://<host>:<port>/libs/social/badges/badgeResourceCreateServlet with ADMIN credentials.
+   - Check the logs for any error in log file created in 3c.
+
+5. Validate Badges
+
+   - Make a HTTP POST call to http://<host>:<port>/libs/social/badges/badgeResourceValidationServlet with ADMIN credentials.
+   - Check the logs for any error in log file created in 3c.
+
+6. Delete Old Badge - (If validation is passed for all Users in step 5)
+
+   - Make a HTTP POST call to http://<host>:<port>/libs/social/badges/badgeResourceDeleteServlet with ADMIN credentials.
+   - Check the logs for any error in log file created in 3c.
+
+   Note-  This script currently handles single badgingrule and scoring rule configured on system. If string array of scoringrules and 
+          badgingrules is configured on system, this might not work.
+

--- a/bundles/communities-badges-migration/pom.xml
+++ b/bundles/communities-badges-migration/pom.xml
@@ -1,0 +1,566 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+ ADOBE CONFIDENTIAL
+ __________________
+
+  Copyright 2013 Adobe Systems Incorporated
+  All Rights Reserved.
+
+ NOTICE:  All information contained herein is, and remains
+ the property of Adobe Systems Incorporated and its suppliers,
+ if any.  The intellectual and technical concepts contained
+ herein are proprietary to Adobe Systems Incorporated and its
+ suppliers and are protected by trade secret or copyright law.
+ Dissemination of this information or reproduction of this material
+ is strictly forbidden unless prior written permission is obtained
+ from Adobe Systems Incorporated.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <!-- ====================================================================== -->
+    <!-- P A R E N T  P R O J E C T  D E S C R I P T I O N                      -->
+    <!-- ====================================================================== -->
+    <parent>
+        <groupId>com.adobe.cq.social</groupId>
+        <artifactId>socialcommunities-parent</artifactId>
+        <version>1.4.7</version>
+    </parent>
+
+    <!-- ====================================================================== -->
+    <!-- P R O J E C T  D E S C R I P T I O N                                   -->
+    <!-- ====================================================================== -->
+    <groupId>com.adobe.cq.social</groupId>
+    <artifactId>cq-social-badges-migrator</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+    <name>AEM Communities Resource Migrator - Bundle</name>
+
+
+    <!-- ====================================================================== -->
+    <!-- B U I L D   D E F I N I T I O N                                        -->
+    <!-- ====================================================================== -->
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-scr-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-Category>social</Bundle-Category>
+                        <Export-Package>
+                            com.adobe.cq.social.badges.resource.migrator.api
+                        </Export-Package>
+                        <Import-Package>
+                            *
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+
+                <executions>
+                    <execution>
+                        <id>baseline</id>
+                        <goals><goal>baseline</goal></goals>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.sling</groupId>
+                <artifactId>maven-sling-plugin</artifactId>
+                <configuration>
+                    <slingUrl>${sling.url}/crx/repository/crx.default</slingUrl>
+                    <slingUrlSuffix>/libs/social/console/install</slingUrlSuffix>
+                    <usePut>true</usePut>
+                    <skip>true</skip>
+                </configuration>
+                <executions>
+                        <execution>
+                            <id>deploy-to-cq</id>
+                            <phase>install</phase>
+                            <goals>
+                                <goal>install</goal>
+                            </goals>
+                            <configuration>
+                                <user>admin</user>
+                                <password>admin</password>
+                            </configuration>
+                        </execution>
+                    </executions>
+             </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <!-- The release profile builds a source jar containing only the public classes, for javadocs -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                                <configuration>
+                                    <forceCreation>true</forceCreation>
+                                    <includes>
+                                        <include>nothing/*.java</include> <!-- intentionally none-->
+                                    </includes>
+                                    <excludes>
+                                        <exclude>**/impl/**</exclude>
+                                    </excludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- The release profile builds a jar containing only the public classes, for the api jar -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>api-jar</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <configuration>
+                                    <classifier>public-api</classifier>
+                                    <includes>
+                                        <include>nothing/*.class</include> <!-- intentionally none-->
+                                    </includes>
+                                    <excludes>
+                                        <exclude>**/impl/**</exclude>
+                                    </excludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>static-analysis</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>findbugs-maven-plugin</artifactId>
+                        <configuration>
+                            <failOnError>false</failOnError>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+    <!-- ====================================================================== -->
+    <!-- D E P E N D E N C I E S                                                -->
+    <!-- ====================================================================== -->
+    <dependencies>
+
+        <!-- 3rd party libraries -->
+        
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>4.2.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.scr.annotations</artifactId>
+        </dependency>
+	<dependency>
+        <groupId>commons-logging</groupId>
+        <artifactId>commons-logging</artifactId>
+        <version>1.1.1</version>
+</dependency>
+        
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.jcr</groupId>
+            <artifactId>jcr</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.compendium</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.4</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>1.4</version>
+            <scope>provided</scope>
+        </dependency>
+        
+
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.commons.osgi</artifactId>
+            <version>2.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.oltu.oauth2</groupId>
+            <artifactId>org.apache.oltu.oauth2.jwt</artifactId>
+            <version>1.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- ================================================================== -->
+        <!-- Oak -->
+        <!-- ================================================================== -->
+        <dependency>
+            <groupId>org.apache.jackrabbit</groupId>
+            <artifactId>oak-lucene</artifactId>
+            <version>1.2.2</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+          <version>15.0</version>
+          <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.3.2</version>
+            <scope>provided</scope>
+        </dependency>
+        
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.3.2</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- APIs -->
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.api</artifactId>
+            <version>2.7.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.resourceresolver</artifactId>
+            <version>1.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.jcr.api</artifactId>
+            <version>2.2.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.jcr.base</artifactId>
+            <version>2.2.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.commons.json</artifactId>
+            <version>2.0.4-incubator</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.caconfig.api</artifactId>
+            <version>1.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.jcr.resource</artifactId>
+            <version>2.3.7-R1584072</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.sling</groupId>
+                    <artifactId>org.apache.sling.jcr.api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.servlets.post</artifactId>
+            <version>2.3.0</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.sling</groupId>
+                    <artifactId>org.apache.sling.jcr.api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.sling</groupId>
+                    <artifactId>org.apache.sling.jcr.resource</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.settings</artifactId>
+            <version>1.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- CQ Platform -->
+        <dependency>
+            <groupId>com.adobe.granite</groupId>
+            <artifactId>com.adobe.granite.security.user</artifactId>
+            <version>0.1.38</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.day.commons</groupId>
+            <artifactId>day-commons-text</artifactId>
+            <version>1.1.5</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.day.cq</groupId>
+            <artifactId>cq-commons</artifactId>
+            <version>5.6.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.adobe.granite</groupId>
+            <artifactId>com.adobe.granite.socialgraph</artifactId>
+            <version>0.0.14</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.adobe.granite</groupId>
+            <artifactId>com.adobe.granite.ui.commons</artifactId>
+            <version>5.5.148</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.day.cq.wcm</groupId>
+            <artifactId>cq-wcm-foundation</artifactId>
+            <version>5.6.4</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.adobe.granite</groupId>
+            <artifactId>com.adobe.granite.xssprotection</artifactId>
+            <version>5.5.8</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.adobe.granite</groupId>
+            <artifactId>com.adobe.granite.replication.core</artifactId>
+            <version>5.16.20</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.adobe.cq</groupId>
+            <artifactId>cq-analytics-integration</artifactId>
+            <version>1.0.42</version>
+            <scope>provided</scope>
+        </dependency>
+
+		<dependency>
+			<groupId>com.adobe.cq.social</groupId>
+			<artifactId>cq-social-console</artifactId>
+			<version>1.3.0</version>
+			<scope>provided</scope>
+		</dependency>
+		
+		
+		
+		<dependency>
+			<groupId>com.adobe.cq.social</groupId>
+            <artifactId>cq-social-scoring-api</artifactId>
+            <version>2.3.0</version>
+			<scope>provided</scope>
+		</dependency>
+		
+        <!-- CQ Social  -->
+        
+        <dependency>
+            <groupId>com.adobe.cq.social</groupId>
+            <artifactId>cq-socialcommunities-api</artifactId>
+            <version>1.11.170</version>
+            <scope>provided</scope>
+       </dependency>
+        <dependency>
+            <groupId>com.day.cq.wcm</groupId>
+            <artifactId>cq-wcm-webservice-support</artifactId>
+            <version>5.6.4</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- UGC Search -->
+        <dependency>
+            <groupId>com.adobe.cq.social</groupId>
+            <artifactId>cq-social-ugc-search-collections</artifactId>
+            <version>2.3.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.tenant</artifactId>
+            <version>1.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- msm needed explicitly -->
+        <dependency>
+            <groupId>com.day.cq.wcm</groupId>
+            <artifactId>cq-msm-api</artifactId>
+            <version>5.5.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.jackrabbit</groupId>
+            <artifactId>jackrabbit-api</artifactId>
+            <version>2.8.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.jackrabbit</groupId>
+            <artifactId>jackrabbit-jcr-commons</artifactId>
+            <version>2.8.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+              <groupId>com.adobe.granite</groupId>
+              <artifactId>com.adobe.granite.confmgr</artifactId>
+              <version>1.2.6</version>
+        </dependency>
+        <!-- ================================================================== -->
+        <!-- TEST -->
+        <!-- ================================================================== -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>1.1.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.9.5</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.commons.testing</artifactId>
+            <version>2.0.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.day.crx.sling</groupId>
+            <artifactId>com.day.crx.sling.testing</artifactId>
+            <version>2.0.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.day.cq</groupId>
+            <artifactId>cq-testing</artifactId>
+            <version>5.5.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.jackrabbit.vault</groupId>
+            <artifactId>org.apache.jackrabbit.vault</artifactId>
+            <version>3.1.26</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.jackrabbit</groupId>
+            <artifactId>jackrabbit-jcr-tests</artifactId>
+            <version>2.8.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.adobe.granite</groupId>
+            <artifactId>com.adobe.granite.translation.core</artifactId>
+            <version>1.0.22</version>
+            <scope>test</scope>
+        </dependency>
+
+       
+    </dependencies>
+
+</project>
+

--- a/bundles/communities-badges-migration/src/main/java/com/adobe/cq/social/badges/resource/migrator/api/BadgeResourceCreateServlet.java
+++ b/bundles/communities-badges-migration/src/main/java/com/adobe/cq/social/badges/resource/migrator/api/BadgeResourceCreateServlet.java
@@ -1,0 +1,69 @@
+package com.adobe.cq.social.badges.resource.migrator.api;
+
+import javax.servlet.Servlet;
+
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
+import org.apache.felix.scr.annotations.Reference;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.servlets.SlingAllMethodsServlet;
+import org.apache.sling.settings.SlingSettingsService;
+import org.osgi.service.component.ComponentContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.cq.social.badges.resource.migrator.internal.BadgesMigrationUtils;
+import com.adobe.cq.social.badges.resource.migrator.service.BadgeResourceMigrationService;
+
+
+@Component(metatype = true, immediate = true, label = "BadgeResourceCreateServlet", description = "This Servlets create the new badges")
+@Service(value = Servlet.class)
+@Properties(value = {
+        @Property(name = "sling.servlet.extensions", value = "json", propertyPrivate = true),
+        @Property(name = "sling.servlet.paths", value = "/libs/social/badges/badgeResourceCreateServlet", propertyPrivate = true),
+        @Property(name = "sling.servlet.methods", value = {"POST"}, propertyPrivate = true),
+        @Property(name = "sleep.time", value = {"2000"}, propertyPrivate = false)
+})
+
+public class BadgeResourceCreateServlet extends SlingAllMethodsServlet {
+
+    private static final long serialVersionUID = 1L;
+    
+    @Reference
+    private SlingSettingsService settingsService;
+    
+    @Reference
+    private BadgeResourceMigrationService badgeResourceMigrationService;
+    
+    private final Logger log = LoggerFactory.getLogger(BadgeResourceCreateServlet.class);
+
+    protected void activate(ComponentContext componentContext) throws Exception {
+    	log.info("Activated: BadgeResourceCreateServlet started");
+        
+    }
+
+    protected void deactivate(ComponentContext context) {
+        log.info("Deactivated: BadgeResourceCreateServlet stopped");
+    }
+
+    public void doPost(SlingHttpServletRequest req, SlingHttpServletResponse resp) {
+        getRequestHandler(req, resp);
+    }
+
+    private void getRequestHandler(SlingHttpServletRequest req, SlingHttpServletResponse resp) {
+        log.info("Got Badge Creation Request");
+        if (!BadgesMigrationUtils.isPublishMode(settingsService)) {
+            log.info("Migration Request Not Received on Publish Aborting it");
+            return;
+        }
+        try {
+			badgeResourceMigrationService.createNewBadges(req, resp);
+		} catch (Exception e) {
+			log.error("Error in creating new badges");
+		}
+    }
+    
+}

--- a/bundles/communities-badges-migration/src/main/java/com/adobe/cq/social/badges/resource/migrator/api/BadgeResourceDeletionServlet.java
+++ b/bundles/communities-badges-migration/src/main/java/com/adobe/cq/social/badges/resource/migrator/api/BadgeResourceDeletionServlet.java
@@ -1,0 +1,70 @@
+package com.adobe.cq.social.badges.resource.migrator.api;
+
+import javax.servlet.Servlet;
+
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
+import org.apache.felix.scr.annotations.Reference;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.servlets.SlingAllMethodsServlet;
+import org.apache.sling.settings.SlingSettingsService;
+import org.osgi.service.component.ComponentContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.cq.social.badges.resource.migrator.internal.BadgesMigrationUtils;
+import com.adobe.cq.social.badges.resource.migrator.service.BadgeResourceMigrationService;
+
+
+@Component(metatype = true, immediate = true, label = "BadgeResourceDeletionServlet", description = "This servlet handles the delete request of old badges")
+@Service(value = Servlet.class)
+@Properties(value = {
+        @Property(name = "sling.servlet.extensions", value = "json", propertyPrivate = true),
+        @Property(name = "sling.servlet.paths", value = "/libs/social/badges/badgeResourceDeleteServlet", propertyPrivate = true),
+        @Property(name = "sling.servlet.methods", value = {"POST"}, propertyPrivate = true),
+        @Property(name = "sleep.time", value = {"2000"}, propertyPrivate = false)
+})
+
+public class BadgeResourceDeletionServlet extends SlingAllMethodsServlet {
+
+    private static final long serialVersionUID = 1L;
+    
+
+    @Reference
+    private SlingSettingsService settingsService;
+    
+    @Reference
+    private BadgeResourceMigrationService badgeResourceMigrationService;
+    
+    private final Logger log = LoggerFactory.getLogger(BadgeResourceDeletionServlet.class);
+    
+
+    protected void activate(ComponentContext componentContext) throws Exception {
+        log.info("Activated: BadgeResourceDeletionServlet started");
+    }
+
+    protected void deactivate(ComponentContext context) {
+        log.info("Deactivated: BadgeResourceDeletionServlet stopped");
+    }
+
+    public void doPost(SlingHttpServletRequest req, SlingHttpServletResponse resp) {
+        getRequestHandler(req, resp);
+    }
+
+    private void getRequestHandler(SlingHttpServletRequest req, SlingHttpServletResponse resp) {
+    	log.info("Got Badge Migration Request");
+        if (!BadgesMigrationUtils.isPublishMode(settingsService)) {
+            log.info("Migration Request Received on Publish Aborting it");
+            return;
+        }
+        try {
+			badgeResourceMigrationService.deleteOldBadges(req, resp);
+		} catch (Exception e) {
+			log.error("Error in deleting old badges");
+		}
+    }
+   
+}

--- a/bundles/communities-badges-migration/src/main/java/com/adobe/cq/social/badges/resource/migrator/api/BadgeResourceValidationServlet.java
+++ b/bundles/communities-badges-migration/src/main/java/com/adobe/cq/social/badges/resource/migrator/api/BadgeResourceValidationServlet.java
@@ -1,0 +1,70 @@
+package com.adobe.cq.social.badges.resource.migrator.api;
+
+import javax.servlet.Servlet;
+
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
+import org.apache.felix.scr.annotations.Reference;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.servlets.SlingAllMethodsServlet;
+import org.apache.sling.settings.SlingSettingsService;
+import org.osgi.service.component.ComponentContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.cq.social.badges.resource.migrator.internal.BadgesMigrationUtils;
+import com.adobe.cq.social.badges.resource.migrator.service.BadgeResourceValidationService;
+
+
+@Component(metatype = true, immediate = true, label = "BadgeResourceCreateServlet", description = "This Servlets create the new badges")
+@Service(value = Servlet.class)
+@Properties(value = {
+        @Property(name = "sling.servlet.extensions", value = "json", propertyPrivate = true),
+        @Property(name = "sling.servlet.paths", value = "/libs/social/badges/badgeResourceValidationServlet", propertyPrivate = true),
+        @Property(name = "sling.servlet.methods", value = {"POST"}, propertyPrivate = true),
+        @Property(name = "sleep.time", value = {"2000"}, propertyPrivate = false)
+})
+
+public class BadgeResourceValidationServlet extends SlingAllMethodsServlet {
+
+    private static final long serialVersionUID = 1L;
+    
+    private static long delay = 2000;
+
+    @Reference
+    private SlingSettingsService settingsService;
+    
+    @Reference
+    private BadgeResourceValidationService badgeResourceValidationService;
+    
+    private final Logger log = LoggerFactory.getLogger(BadgeResourceValidationServlet.class);
+
+    protected void activate(ComponentContext componentContext) throws Exception {
+        log.info("Activated: BadgeResourceValidationServlet started");
+    }
+    
+    protected void deactivate(ComponentContext context) {
+        log.info("Deactivated: BadgeResourceValidationServlet stopped");
+    }
+
+    public void doPost(SlingHttpServletRequest req, SlingHttpServletResponse resp) {
+        getRequestHandler(req, resp);
+    }
+
+    private void getRequestHandler(SlingHttpServletRequest req, SlingHttpServletResponse resp) {
+        log.info("Got Badge Validation Request");
+        if (!BadgesMigrationUtils.isPublishMode(settingsService)) {
+            log.info("Validation Request Not Received on Publish Aborting it");
+            return;
+        }
+        try {
+        	badgeResourceValidationService.validateNewBadges(req, delay, resp);
+		} catch (Exception e) {
+			log.error("Error in validating badges");
+		}
+    }
+    
+}

--- a/bundles/communities-badges-migration/src/main/java/com/adobe/cq/social/badges/resource/migrator/impl/BadgeResourceMigrationServiceImpl.java
+++ b/bundles/communities-badges-migration/src/main/java/com/adobe/cq/social/badges/resource/migrator/impl/BadgeResourceMigrationServiceImpl.java
@@ -1,0 +1,380 @@
+package com.adobe.cq.social.badges.resource.migrator.impl;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.jcr.RepositoryException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Reference;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ValueMap;
+import org.osgi.service.event.EventAdmin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.cq.social.badges.resource.migrator.internal.BadgesMigrationUtils;
+import com.adobe.cq.social.badges.resource.migrator.internal.BadgingConstants;
+import com.adobe.cq.social.badges.resource.migrator.service.BadgeResourceMigrationService;
+import com.adobe.cq.social.badging.api.BadgingService;
+import com.adobe.cq.social.community.api.CommunityContext;
+import com.adobe.cq.social.scoring.api.ScoringConstants;
+import com.adobe.cq.social.scoring.api.ScoringService;
+import com.adobe.cq.social.srp.SocialResourceProvider;
+import com.adobe.cq.social.ugcbase.SocialUtils;
+import com.adobe.cq.social.user.internal.UserBadgeUtils;
+import com.adobe.cq.social.user.internal.UserProfileBadge;
+import com.adobe.granite.security.user.UserManagementService;
+
+@Component(immediate = true)
+@Service(value = BadgeResourceMigrationService.class)
+public class BadgeResourceMigrationServiceImpl implements BadgeResourceMigrationService{
+
+	private final Logger log = LoggerFactory.getLogger(BadgeResourceMigrationService.class);
+
+	@Reference
+	private UserManagementService userManagementService;
+
+	@Reference
+	private EventAdmin eventAdmin;
+
+	@Reference
+	private BadgingService badgingService;
+
+	@Reference
+	private ScoringService scoringService;
+
+
+	@Override
+	public void createNewBadges(SlingHttpServletRequest req , SlingHttpServletResponse resp) throws Exception {
+
+		log.info("[BADGEMIGRATIONTASK] BadgeCreation Start Time : " + System.currentTimeMillis() / 1000);
+
+		ResourceResolver resourceResolver = req.getResourceResolver();
+		Resource componentResource = resourceResolver.getResource(BadgingConstants.COMPONENT_RESOURCE_PATH);
+		Resource scoreRuleResource = resourceResolver.getResource(BadgingConstants.NEW_SCORING_NAME_PROP);
+		Resource badgingRuleResource = resourceResolver.getResource(BadgingConstants.NEW_BADGING_RULE_PROP);
+		if(componentResource == null) {
+			log.error("[BadgesMigrationTask] componentResource null ");
+			return;
+		}else if (scoreRuleResource ==null){
+			log.error("[BadgesMigrationTask] scoring null");
+			return;
+		}
+
+		Resource resource = req.getResource();
+		String userId = req.getParameter("authid");                         // createBadges for only single user.
+		if(userId !=null){
+			createNewEarnedBadges(resourceResolver,userId, resource,badgingRuleResource, componentResource);        	
+			createNewAssignedBadges(resourceResolver,userId , badgingRuleResource, componentResource);
+			log.info("[BadgesMigrationTask] BadgeCreation End TIme : " + System.currentTimeMillis() / 1000);
+			return;
+		}
+
+		// getting total number of scoring nodes       
+		final SocialResourceProvider srp = getSRP(resourceResolver, componentResource);
+		long total_scores = 0;
+		try {
+			total_scores = scoringService.getTotalNumberOfScores(resourceResolver, componentResource, scoreRuleResource);         // not able to get total number of scoring node present
+		} catch (RepositoryException e) {
+			log.error("[BadgesMigrationTask] error in getting scoring number   {}", e.getCause());
+			return;
+		}
+
+		// getting leaderboard Path		
+		log.info("[BadgesMigrationTask] scoring number is  {}", total_scores);
+		String leaderboardPath = null;
+		try {
+			leaderboardPath = scoringService.getScoreResourcePath(resourceResolver, null, componentResource, scoreRuleResource);
+		} catch (RepositoryException e1) {
+			log.error("[BadgesMigrationTask] error in getting scoring path");
+		}
+		if(leaderboardPath == null){
+			log.error("[BadgesMigrationTask] error in getting scoring path");
+			return;
+		}
+		log.info("[BadgesMigrationTask] leadeboardpath: {} ",leaderboardPath);
+
+
+		final List<Map.Entry<String, Boolean>> order = new ArrayList<Map.Entry<String, Boolean>>();
+		// sort based on score value
+		order.add(new AbstractMap.SimpleEntry<String, Boolean>(ScoringConstants.SCORE_VALUE_PROP, true));
+		// break ties with userid
+		order.add(new AbstractMap.SimpleEntry<String, Boolean>(ScoringConstants.USERID_PROP, true));
+
+		int offset =0;
+		int size = 10;
+		int totalLeaderboardItmes = 0;
+		while (offset <=total_scores) {
+			Iterator<Resource> scores =
+					srp.listChildren(leaderboardPath, resourceResolver, offset, size, order);
+			String authId = "";
+			while (scores.hasNext()) {
+				try {
+					Resource nt = scores.next();
+					totalLeaderboardItmes++;
+					try {
+						authId = nt.getValueMap().get("userIdentifier").toString();
+					} catch (Exception e) {
+						log.error("[BADGEMIGRATIONTASK]  Did not get the authid of userid from scoringNode");
+						continue;
+					}
+					if (badgingService != null) {
+						createNewEarnedBadges(resourceResolver,authId, resource, badgingRuleResource, componentResource);
+						createNewAssignedBadges(resourceResolver,authId , badgingRuleResource, componentResource);
+						
+					}
+				} catch (Exception e) {
+					log.error("Error in creating badge for authid : {} error:{} ", authId, e.getCause());
+				}
+			}
+			offset+=size;
+		}
+
+		log.info("[BadgesMigrationTask] total LeaderBoardItems iterated : " + totalLeaderboardItmes);
+		log.info("[BadgesMigrationTask] BadgeCreation End TIme : " + System.currentTimeMillis() / 1000);
+
+	}
+
+
+
+
+
+	private int createNewEarnedBadges(ResourceResolver resourceResolver,String authId, Resource resource, Resource badgingRuleResource, Resource componentResource) throws Exception{
+
+		UserBadgeUtils badgeUtils = new UserBadgeUtils(resourceResolver, badgingService, authId);
+		CommunityContext communityContext = resource.adaptTo(CommunityContext.class);
+		if (communityContext != null && StringUtils.isBlank(communityContext.getSiteId())) {
+			communityContext = null;
+		}
+		List<UserProfileBadge> earnedBadges = badgeUtils.getBadges(communityContext, BadgingService.EARNED_BADGES);
+		Set<String> userBadgesSet = new HashSet<String>();
+		for (UserProfileBadge badge:earnedBadges){
+			userBadgesSet.add(badge.getUserBadgeResource().getValueMap().get("badgeContentPath", String.class));
+		}
+		Collections.sort(earnedBadges, new CustomComparator());
+		int count = 0 ;
+		for (UserProfileBadge badge:earnedBadges) {
+			Resource badgeResource = badge.getUserBadgeResource();
+			ValueMap  badgeMap = badgeResource.getValueMap();
+			String currentBadgeContentPath = badgeMap.get("badgeContentPath", String.class);
+			String newBadgeContentPath = BadgesMigrationUtils.getNewBadgeContentPath(currentBadgeContentPath, resourceResolver);
+			if(currentBadgeContentPath.startsWith("/etc") && !userBadgesSet.contains(newBadgeContentPath)){
+				final Map<String, Object> badgingProps = new HashMap<String, Object>();
+				Calendar earnedDate  = badge.getUserBadgeResource().getValueMap().get(BadgingService.BADGE_EARNED_DATE_PROP, Calendar.class);
+				int score = badge.getEarnedScore();
+				badgingProps.put(ScoringConstants.COMPONENT_PATH_PROP, BadgingConstants.COMPONENT_RESOURCE_PATH);
+				badgingProps.put(BadgingService.BADGE_EARNED_SCORE_PROP, score);
+				badgingProps.put(BadgingService.BADGE_EARNED_DATE_PROP, earnedDate);
+				badgingService.saveBadge(resourceResolver, authId, badgingRuleResource, componentResource, newBadgeContentPath, false,badgingProps);
+				log.info("[BADGEMIGRATIONTASK] new earned badges created for authId:{} badge: {}" , authId, newBadgeContentPath);
+				count++;
+			}
+		}
+		return count;
+	}
+
+	
+	
+	public class CustomComparator implements Comparator<UserProfileBadge> {
+	    @Override
+	    public int compare(UserProfileBadge u1, UserProfileBadge u2) {
+	    	Integer u1Score = u1.getEarnedScore();
+	    	Integer u2Score =  u2.getEarnedScore();
+	        return u1Score.compareTo(u2Score);
+	    }
+	}
+	
+
+	private int createNewAssignedBadges(ResourceResolver resourceResolver,String authId, Resource resource, Resource componentResource) throws Exception {
+
+		UserBadgeUtils badgeUtils = new UserBadgeUtils(resourceResolver, badgingService, authId);
+		CommunityContext communityContext = resource.adaptTo(CommunityContext.class);
+		if (communityContext != null && StringUtils.isBlank(communityContext.getSiteId())) {
+			communityContext = null;
+		}
+		List<UserProfileBadge>  assignBadges = badgeUtils.getBadges(communityContext, BadgingService.ASSIGNED_BADGES);
+		Set<String> userBadgesSet = new HashSet<String>();
+		for (UserProfileBadge badge:assignBadges){
+			userBadgesSet.add(badge.getUserBadgeResource().getValueMap().get("badgeContentPath", String.class));
+		}
+		int count = 0; 
+		for (UserProfileBadge badge: assignBadges) {
+			String currentBadgeContentPath = badge.getUserBadgeResource().getValueMap().get("badgeContentPath", String.class);
+			String newBadgeContentPath = BadgesMigrationUtils.getNewBadgeContentPath(currentBadgeContentPath, resourceResolver);
+			if(currentBadgeContentPath.startsWith("/etc") && !userBadgesSet.contains(newBadgeContentPath)) {
+				Calendar earnedDate  = badge.getUserBadgeResource().getValueMap().get(BadgingService.BADGE_EARNED_DATE_PROP, Calendar.class);
+				final Map<String, Object> badgeProps = new HashMap<String, Object>();
+				badgeProps.put(BadgingService.BADGE_EARNED_DATE_PROP, earnedDate);
+				badgingService.saveBadge(resourceResolver, authId, null, componentResource, newBadgeContentPath, true, badgeProps);
+				log.info("[BADGEMIGRATIONTASK] new assigned badges created for authId:{} badge: {}" , authId, newBadgeContentPath);
+			}
+		}
+		return count;
+	}
+
+
+	@Override
+	public void deleteOldBadges(SlingHttpServletRequest req,SlingHttpServletResponse resp ) throws Exception {
+		log.info("[BADGEMIGRATIONTASK] Deleting badges Start Time : " + System.currentTimeMillis() / 1000);
+		ResourceResolver resourceResolver = req.getResourceResolver();
+		Resource componentResource = resourceResolver.getResource(BadgingConstants.COMPONENT_RESOURCE_PATH);
+		Resource scoreRuleResource = resourceResolver.getResource(BadgingConstants.NEW_SCORING_NAME_PROP);
+		Resource oldBadgingRuleResource = resourceResolver.getResource(BadgingConstants.OLD_BADGING_RULE_PROP);
+		if(componentResource == null) {
+			log.error("[BadgesMigrationTask] componentResource null ");
+			return;
+		}else if (scoreRuleResource ==null){
+			log.error("[BadgesMigrationTask] scoring null");
+			return;
+		}
+
+		Resource resource = req.getResource();
+		String authId = req.getParameter("authid");
+		if(authId !=null){
+			if (badgingService != null) {
+				CommunityContext communityContext = resource.adaptTo(CommunityContext.class);
+				if (communityContext != null && StringUtils.isBlank(communityContext.getSiteId())) {
+					communityContext = null;
+				}
+				final UserBadgeUtils badgeUtils = new UserBadgeUtils(resourceResolver, badgingService, authId);
+				List<UserProfileBadge> earnedBadges = badgeUtils.getBadges(communityContext, BadgingService.EARNED_BADGES);
+				List<UserProfileBadge>  assignedBadges = badgeUtils.getBadges(communityContext, BadgingService.ASSIGNED_BADGES);
+
+				deleteBadges(earnedBadges,authId, oldBadgingRuleResource , componentResource, false, resourceResolver );
+				deleteBadges(assignedBadges, authId, null, componentResource, true, resourceResolver);
+			}  
+			return;
+		}
+
+		final SocialResourceProvider srp = getSRP(resourceResolver, componentResource);
+		long total_scores = 0;
+		total_scores = scoringService.getTotalNumberOfScores(resourceResolver, componentResource, scoreRuleResource);
+
+		log.info("[BadgesMigrationTask] scoring number is  {}", total_scores);
+		String leaderboardPath = scoringService.getScoreResourcePath(resourceResolver, null, componentResource, scoreRuleResource);
+
+		if(leaderboardPath == null){
+			log.error("[BadgesMigrationTask] error in getting scoring path");
+			return;
+		}
+
+		log.info("[BadgesMigrationTask] leadeboardpath: {} ",leaderboardPath);
+		final List<Map.Entry<String, Boolean>> order = new ArrayList<Map.Entry<String, Boolean>>();
+		// sort based on score value
+		order.add(new AbstractMap.SimpleEntry<String, Boolean>(ScoringConstants.SCORE_VALUE_PROP, true));
+
+		int offset =0;
+		int size = 10;
+		int totalLeaderboardItmes = 0;
+		while (offset <=total_scores) {
+			Iterator<Resource> scores =
+					srp.listChildren(leaderboardPath, resourceResolver, offset, size, order);
+			while (scores.hasNext()) {
+				Resource nt = scores.next();
+				totalLeaderboardItmes++;
+				try {
+					authId = nt.getValueMap().get("userIdentifier").toString();
+				} catch (Exception e) {
+					log.error("[BADGEMIGRATIONTASK]  Did not get the authid of userid from scoringNode");
+					continue;
+				}
+				if (badgingService != null) {
+					CommunityContext communityContext = resource.adaptTo(CommunityContext.class);
+					if (communityContext != null && StringUtils.isBlank(communityContext.getSiteId())) {
+						communityContext = null;
+					}
+					final UserBadgeUtils badgeUtils = new UserBadgeUtils(resourceResolver, badgingService, authId);
+					List<UserProfileBadge> earnedBadges = badgeUtils.getBadges(communityContext, BadgingService.EARNED_BADGES);
+					List<UserProfileBadge>  assignedBadges = badgeUtils.getBadges(communityContext, BadgingService.ASSIGNED_BADGES);
+					deleteBadges(earnedBadges,authId, oldBadgingRuleResource , componentResource, false, resourceResolver );  // delete earned badges
+					deleteBadges(assignedBadges, authId, null, componentResource, true, resourceResolver);        // delete assigned badges
+				}  
+			}
+			offset+=size;
+		}
+
+		log.info("[BadgesMigrationTask] total LeaderBoardItems iterated : " + totalLeaderboardItmes);
+		log.info("[BadgesMigrationTask] Deleting old badges End TIme : " + System.currentTimeMillis() / 1000);
+
+	}
+
+
+
+
+	private void deleteBadges(List<UserProfileBadge> userBadges, String userId, Resource ruleResource, Resource componentResource, boolean isAssigned, ResourceResolver resourceResolver) {
+
+		Set<String> userBadgesSet = new HashSet<String>();
+		for (UserProfileBadge badge:userBadges){
+			userBadgesSet.add(badge.getUserBadgeResource().getValueMap().get("badgeContentPath", String.class));
+		}
+		for (UserProfileBadge badge:userBadges) {
+			String currentBadgeContentPath = badge.getUserBadgeResource().getValueMap().get("badgeContentPath", String.class);
+			String newBadgeContentPath = BadgesMigrationUtils.getNewBadgeContentPath(currentBadgeContentPath, resourceResolver);
+			
+			if(currentBadgeContentPath.startsWith("/etc") && userBadgesSet.contains(newBadgeContentPath)) {
+				try {
+					badgingService.deleteBadge(resourceResolver, userId, ruleResource, componentResource, currentBadgeContentPath, isAssigned);
+					log.info("[BADGEMIGRATIONTASK] Deleted  badge userid : {} badgeContentPath : {} ",userId, currentBadgeContentPath);
+				} catch (Exception e) {
+					log.error("[BADGEMIGRATIONTASK] Error in deleting badge userid : {} badgeContentPath : {} ",userId, currentBadgeContentPath);
+				}
+			}
+		}
+	}
+
+
+	private  SocialResourceProvider getSRP(final ResourceResolver resolver, final Resource componentResource) {
+		if (componentResource == null) {
+			log.error("can't obtain configured SocialResourceProvider because componentResource is null");
+			return null;
+		}
+
+		final SocialUtils socialUtils = resolver.adaptTo(SocialUtils.class);
+		if (socialUtils == null) {
+			log.error("can't obtain a reference to SocialUtils");
+			return null;
+		}
+
+		SocialResourceProvider srp = socialUtils.getConfiguredProvider(componentResource);
+		if (srp == null) {
+			log.error("can't obtain configured SocialResourceProvider using the componentResource");
+			return null;
+		}
+
+		// the current SRP's resolver is from the componentResource. We want a SRP with the passed-in resolver.
+		final Resource root = resolver.getResource(srp.getASIPath());
+		if (root == null) {
+			log.error("can't read SRP root");
+			return null;
+		}
+
+		srp = socialUtils.getConfiguredProvider(root);
+		if (srp == null) {
+			log.error("can't obtain configured SocialResourceProvider");
+			return null;
+		}
+
+		// initialize the configured SRP
+		srp.setConfig(socialUtils.getStorageConfig(root));
+
+		return srp;
+	}
+
+
+
+}

--- a/bundles/communities-badges-migration/src/main/java/com/adobe/cq/social/badges/resource/migrator/impl/BadgeResourceValidationServiceImpl.java
+++ b/bundles/communities-badges-migration/src/main/java/com/adobe/cq/social/badges/resource/migrator/impl/BadgeResourceValidationServiceImpl.java
@@ -1,0 +1,221 @@
+package com.adobe.cq.social.badges.resource.migrator.impl;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.jcr.RepositoryException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Reference;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ValueMap;
+import org.osgi.service.event.EventAdmin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.cq.social.badges.resource.migrator.internal.BadgesMigrationUtils;
+import com.adobe.cq.social.badges.resource.migrator.internal.BadgingConstants;
+import com.adobe.cq.social.badges.resource.migrator.service.BadgeResourceValidationService;
+import com.adobe.cq.social.badging.api.BadgingService;
+import com.adobe.cq.social.community.api.CommunityContext;
+import com.adobe.cq.social.scoring.api.ScoringConstants;
+import com.adobe.cq.social.scoring.api.ScoringService;
+import com.adobe.cq.social.srp.SocialResourceProvider;
+import com.adobe.cq.social.ugcbase.SocialUtils;
+import com.adobe.cq.social.user.internal.UserBadgeUtils;
+import com.adobe.cq.social.user.internal.UserProfileBadge;
+import com.adobe.granite.security.user.UserManagementService;
+
+@Component(immediate = true)
+@Service(value = BadgeResourceValidationService.class)
+public class BadgeResourceValidationServiceImpl implements BadgeResourceValidationService{
+
+	private final Logger log = LoggerFactory.getLogger(BadgeResourceValidationService.class);
+
+	@Reference
+	private UserManagementService userManagementService;
+
+	@Reference
+	private EventAdmin eventAdmin;
+
+	@Reference
+	private BadgingService badgingService;
+
+	@Reference
+	private ScoringService scoringService;
+
+
+	@Override
+	public void validateNewBadges(SlingHttpServletRequest req, long delay, SlingHttpServletResponse resp) throws Exception {
+
+		log.info("[BADGEMIGRATIONTASK] BadgeValidation Start Time : " + System.currentTimeMillis() / 1000);
+
+		ResourceResolver resourceResolver = req.getResourceResolver();
+		Resource componentResource = resourceResolver.getResource(BadgingConstants.COMPONENT_RESOURCE_PATH);
+		Resource scoreRuleResource = resourceResolver.getResource(BadgingConstants.NEW_SCORING_NAME_PROP);
+		Resource badgingRuleResource = resourceResolver.getResource(BadgingConstants.NEW_BADGING_RULE_PROP);
+		if(componentResource == null) {
+			log.error("[BadgesMigrationTask] componentResource null ");
+			return;
+		}else if (scoreRuleResource ==null){
+			log.error("[BadgesMigrationTask] scoring null");
+			return;
+		}
+
+		Resource resource = req.getResource();
+		String userId = req.getParameter("authid");                         // createBadges for only single user.
+		if(userId !=null){
+			validateBadges(resourceResolver,userId, resource,badgingRuleResource, componentResource);        	
+			return;
+		}
+
+		// getting total number of scoring nodes       
+		final SocialResourceProvider srp = getSRP(resourceResolver, componentResource);
+		long total_scores = 0;
+		try {
+			total_scores = scoringService.getTotalNumberOfScores(resourceResolver, componentResource, scoreRuleResource);         // not able to get total number of scoring node present
+		} catch (RepositoryException e) {
+			log.error("[BadgesMigrationTask] error in getting scoring number   {}", e.getCause());
+			return;
+		}
+
+		// getting leaderboard Path		
+		log.info("[BadgesMigrationTask] scoring number is  {}", total_scores);
+		String leaderboardPath = null;
+		try {
+			leaderboardPath = scoringService.getScoreResourcePath(resourceResolver, null, componentResource, scoreRuleResource);
+		} catch (RepositoryException e1) {
+			log.error("[BadgesMigrationTask] error in getting scoring path");
+		}
+		if(leaderboardPath == null){
+			log.error("[BadgesMigrationTask] error in getting scoring path");
+		}
+		log.info("[BadgesMigrationTask] leadeboardpath: {} ",leaderboardPath);
+
+
+		final List<Map.Entry<String, Boolean>> order = new ArrayList<Map.Entry<String, Boolean>>();
+		// sort based on score value
+		order.add(new AbstractMap.SimpleEntry<String, Boolean>(ScoringConstants.SCORE_VALUE_PROP, true));
+		// break ties with userid
+		order.add(new AbstractMap.SimpleEntry<String, Boolean>(ScoringConstants.USERID_PROP, true));
+
+		int offset =0;
+		int size = 10;
+		int totalLeaderboardItmes = 0;
+		while (offset <=total_scores) {
+			Iterator<Resource> scores =
+					srp.listChildren(leaderboardPath, resourceResolver, offset, size, order);
+			String authId = "";
+			while (scores.hasNext()) {
+				try {
+					Resource nt = scores.next();
+					totalLeaderboardItmes++;
+					try {
+						authId = nt.getValueMap().get("userIdentifier").toString();
+					} catch (Exception e) {
+						log.error("[BADGEMIGRATIONTASK]  Did not get the authid of userid from scoringNode");
+						continue;
+					}
+					if (badgingService != null) {
+						validateBadges(resourceResolver,authId, resource, badgingRuleResource, componentResource);
+					}
+				} catch (Exception e) {
+					log.error("Error in creating badge for authid : {} error:{} ", authId, e.getCause());
+				}
+			}
+			offset+=size;
+		}
+
+		log.info("[BadgesMigrationTask] total LeaderBoardItems iterated : " + totalLeaderboardItmes);
+		log.info("[BadgesMigrationTask] BadgeValidation End TIme : " + System.currentTimeMillis() / 1000);
+
+	}
+
+
+	private void validateBadges(ResourceResolver resourceResolver,String authId, Resource resource, Resource badgingRuleResource, Resource componentResource) throws Exception{
+
+		UserBadgeUtils badgeUtils = new UserBadgeUtils(resourceResolver, badgingService, authId);
+		CommunityContext communityContext = resource.adaptTo(CommunityContext.class);
+		if (communityContext != null && StringUtils.isBlank(communityContext.getSiteId())) {
+			communityContext = null;
+		}
+		List<UserProfileBadge> allBadges = badgeUtils.getBadges(communityContext, BadgingService.ALL_BADGES);
+		
+		Set<String> userBadgesSet = new HashSet<String>();
+		for (UserProfileBadge badge:allBadges){
+			String badgePath = badge.getUserBadgeResource().getValueMap().get("badgeContentPath", String.class);
+			if(userBadgesSet.contains(badgePath)){
+				log.error("Validation failed, Duplicate Badge: useri:{} badgePath:{}", authId , badgePath);
+				return;
+			}else{
+				userBadgesSet.add(badgePath);
+			}
+			     
+		}
+		for (UserProfileBadge badge:allBadges) {
+			Resource badgeResource = badge.getUserBadgeResource();
+			ValueMap  badgeMap = badgeResource.getValueMap();
+			String currentBadgeContentPath = badgeMap.get("badgeContentPath", String.class);
+			String newBadgeContentPath = BadgesMigrationUtils.getNewBadgeContentPath(currentBadgeContentPath, resourceResolver);
+			if(currentBadgeContentPath.startsWith("/etc") && !userBadgesSet.contains(newBadgeContentPath)){
+				log.info("Validation failed: userid:{} badgePath:{}", authId , currentBadgeContentPath);
+			}
+		}
+		log.info("Validation Passed: userid:{}",authId);
+		
+	}
+
+	
+	
+	
+
+	private  SocialResourceProvider getSRP(final ResourceResolver resolver, final Resource componentResource) {
+		if (componentResource == null) {
+			log.error("can't obtain configured SocialResourceProvider because componentResource is null");
+			return null;
+		}
+
+		final SocialUtils socialUtils = resolver.adaptTo(SocialUtils.class);
+		if (socialUtils == null) {
+			log.error("can't obtain a reference to SocialUtils");
+			return null;
+		}
+
+		SocialResourceProvider srp = socialUtils.getConfiguredProvider(componentResource);
+		if (srp == null) {
+			log.error("can't obtain configured SocialResourceProvider using the componentResource");
+			return null;
+		}
+
+		// the current SRP's resolver is from the componentResource. We want a SRP with the passed-in resolver.
+		final Resource root = resolver.getResource(srp.getASIPath());
+		if (root == null) {
+			log.error("can't read SRP root");
+			return null;
+		}
+
+		srp = socialUtils.getConfiguredProvider(root);
+		if (srp == null) {
+			log.error("can't obtain configured SocialResourceProvider");
+			return null;
+		}
+
+		// initialize the configured SRP
+		srp.setConfig(socialUtils.getStorageConfig(root));
+
+		return srp;
+	}
+
+
+
+}

--- a/bundles/communities-badges-migration/src/main/java/com/adobe/cq/social/badges/resource/migrator/internal/BadgesMigrationUtils.java
+++ b/bundles/communities-badges-migration/src/main/java/com/adobe/cq/social/badges/resource/migrator/internal/BadgesMigrationUtils.java
@@ -1,0 +1,104 @@
+package com.adobe.cq.social.badges.resource.migrator.internal;
+
+import javax.annotation.Nonnull;
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.settings.SlingSettingsService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BadgesMigrationUtils {
+	
+	private static final Logger log = LoggerFactory.getLogger(BadgesMigrationUtils.class);
+
+	public static NodeIterator getScoringNodes(ResourceResolver resourceResolver, String leaderBoardPath) {
+
+		 Session session = resourceResolver.adaptTo(Session.class);
+		 Node scoringNodes = null;
+		log.error(" in getting scoring node  ");
+		// String  componentPath = DigestUtils.sha256Hex(BadgingConstants.COMPONENT_RESOURCE_PATH);
+		 try {
+			 scoringNodes = session.getNode(leaderBoardPath);
+		 } catch (Exception e) {
+			 log.error("error in getting scoring node {} ", e.getMessage() );
+			 return null;
+		 }		
+
+		 NodeIterator sitesIterator = null;
+		 try {
+			 sitesIterator = scoringNodes.getNodes();
+		 } catch (Exception e) {
+			 log.error("error in getting scoring iterator {} ", e.getMessage() );
+			 return null;
+		 }
+
+		 return sitesIterator;
+
+	 }
+	 
+	 private static String getBadgeResourceName(@Nonnull final String rulePath, @Nonnull final String componentPath) {
+		        // get badge root path for user
+
+		        // a badge is associated with a rule + where the rule was located
+		        // need to hash the leaf node since it is too long
+		        // insert invalid jcr node /:/ in case (almost 0 probability) rulePath + componentPath is not unique
+		        return DigestUtils.sha256Hex(rulePath + "/:/" + componentPath);
+		    }
+	 
+	 
+	 public static String getNewAssignedBadgesPath(String badgeName, ResourceResolver resourceResolver){
+		 
+         String  componentPath	 = BadgingConstants.COMPONENT_RESOURCE_PATH;
+         String newBadgeContentPath = getNewBadgeContentPath(badgeName, resourceResolver);
+		 return getBadgeResourceName(newBadgeContentPath, componentPath);
+	 }
+	 
+	public static String getNewTopEarnedBadgesPath(String badgeName, ResourceResolver resourceResolver){
+		 
+		String  componentPath	 = BadgingConstants.COMPONENT_RESOURCE_PATH;
+        String rulePath = BadgingConstants.NEW_BADGING_RULE_PROP;
+	    return getBadgeResourceName(rulePath, componentPath);
+	 }
+	 
+
+   	public static String getNewEarnedBadgesPath(String badgeName, ResourceResolver resourceResolver) {
+   		String  componentPath	 = BadgingConstants.COMPONENT_RESOURCE_PATH;
+        String rulePath = BadgingConstants.NEW_BADGING_RULE_PROP;
+        String newBadgeContentPath = getNewBadgeContentPath(badgeName, resourceResolver);
+        String badgeSRPResourceName =  getBadgeResourceName(rulePath, componentPath);
+        return  getBadgeHistoryResourceName(badgeSRPResourceName, newBadgeContentPath);
+	}
+	
+    public static String getNewBadgeContentPath(String currentBadgeContentPath, ResourceResolver resourceResolver) {
+    	
+        String libsImagePath = currentBadgeContentPath.replaceFirst("/etc", BadgingConstants.LIBS_IMAGES_PATH);
+        Resource libsResource = resourceResolver.getResource(libsImagePath);
+        if(libsResource != null)
+        	 return libsResource.getPath();
+        String contentImagePath = currentBadgeContentPath.replaceFirst("/etc", BadgingConstants.CONTENT_IMAGES_PATH);
+        Resource contentResource = resourceResolver.getResource(contentImagePath);
+        if(contentResource != null)
+        	 return contentResource.getPath();
+        return null;
+	}
+    
+    private static String getBadgeHistoryResourceName(@Nonnull final String currentBadgePath, @Nonnull final String badgeContentPath) {
+    	return currentBadgePath + "_" + DigestUtils.sha256Hex(badgeContentPath);
+    }
+    
+    public static void change(Node node, String newName) throws RepositoryException {
+        node.getSession().move(node.getPath(), node.getParent().getPath() + "/" + newName);
+   }
+    
+    public static boolean isPublishMode(SlingSettingsService slingSettingsService){
+        return slingSettingsService != null && slingSettingsService.getRunModes().contains("publish");
+    }
+    
+	
+}

--- a/bundles/communities-badges-migration/src/main/java/com/adobe/cq/social/badges/resource/migrator/internal/BadgingConstants.java
+++ b/bundles/communities-badges-migration/src/main/java/com/adobe/cq/social/badges/resource/migrator/internal/BadgingConstants.java
@@ -1,0 +1,20 @@
+package com.adobe.cq.social.badges.resource.migrator.internal;
+
+public class BadgingConstants {
+	
+     public static final String NEW_SCORING_NAME_PROP = "/libs/settings/community/scoring/rules/forums-scoring";      // new scoring path
+    
+     public static final  String NEW_BADGING_RULE_PROP = "/libs/settings/community/badging/rules/forums-badging";     // new badging path
+
+     public static final   String COMPONENT_RESOURCE_PATH = "/content/sites/test/en/jcr:content";    // site path where the rule path is configured
+     
+     public static final String  OLD_SCORING_NAME_PROP = "/etc/community/scoring/rules/forums-scoring";      // old scoring path
+     
+     public static final  String OLD_BADGING_RULE_PROP = "/etc/community/badging/rules/forums-badging";      // old badging path
+   
+     public static final String LIBS_IMAGES_PATH = "/libs";
+     
+     public static final String CONTENT_IMAGES_PATH = "/content";
+     
+
+}

--- a/bundles/communities-badges-migration/src/main/java/com/adobe/cq/social/badges/resource/migrator/service/BadgeResourceMigrationService.java
+++ b/bundles/communities-badges-migration/src/main/java/com/adobe/cq/social/badges/resource/migrator/service/BadgeResourceMigrationService.java
@@ -1,0 +1,11 @@
+package com.adobe.cq.social.badges.resource.migrator.service;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+
+public interface BadgeResourceMigrationService {
+
+    public void createNewBadges(SlingHttpServletRequest req, SlingHttpServletResponse resp) throws Exception;
+    
+    public void deleteOldBadges(SlingHttpServletRequest req, SlingHttpServletResponse resp) throws Exception;
+}

--- a/bundles/communities-badges-migration/src/main/java/com/adobe/cq/social/badges/resource/migrator/service/BadgeResourceValidationService.java
+++ b/bundles/communities-badges-migration/src/main/java/com/adobe/cq/social/badges/resource/migrator/service/BadgeResourceValidationService.java
@@ -1,0 +1,9 @@
+package com.adobe.cq.social.badges.resource.migrator.service;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+
+public interface BadgeResourceValidationService {
+
+    public void validateNewBadges(SlingHttpServletRequest req, long delay, SlingHttpServletResponse resp) throws Exception;
+}


### PR DESCRIPTION
Before 0dt(<=6.3) badges images were stored in etc path which moved to content and libs in 0dt changes. For a user badges information is stored under profile node in SRP, so without migration the old created badges would continue pointing to etc paths. This commit has badges migration code which will delete the old badges in UGC and created new badges with updated paths.